### PR TITLE
Fix like counter drift + disable hearts on cover

### DIFF
--- a/src/components/magazine/MagazineViewer.tsx
+++ b/src/components/magazine/MagazineViewer.tsx
@@ -54,6 +54,8 @@ export default function MagazineViewer({ articles }: { articles: Article[] }) {
   const lastTouchTap = useRef({ time: 0, x: 0, y: 0 });
   const lastMouseTap = useRef({ time: 0, x: 0, y: 0 });
   const lastTouchDoubleTap = useRef(0);
+  const currentIndexRef = useRef(currentIndex);
+  currentIndexRef.current = currentIndex;
 
   const clearHideTimer = useCallback(() => {
     if (hideTimer.current) { clearTimeout(hideTimer.current); hideTimer.current = null; }
@@ -89,6 +91,7 @@ export default function MagazineViewer({ articles }: { articles: Article[] }) {
   }, []);
 
   const fireDoubleTap = useCallback((x: number, y: number) => {
+    if (currentIndexRef.current === 0) return; // no hearts on cover
     spawnHeart(x, y);
     setDoubleTapEvent({ x, y, id: Date.now() });
   }, [spawnHeart]);


### PR DESCRIPTION
## Summary
- Suppress liked-status poll during toggle (was only suppressing stats poll)
- Sync likedRef immediately on toggle, not via post-render useEffect
- Guard fireDoubleTap with currentIndex check to skip cover panel

## Test plan
- [x] 100/100 e2e tests pass across all 4 device projects
- [ ] Manual test: rapid-tap like button, verify count stability

🤖 Generated with [Claude Code](https://claude.com/claude-code)