### PR TITLE
Fix like counter snap-back: replace broken incrementField

### DIFF
--- a/src/lib/firebase/firestore-rest.ts
+++ b/src/lib/firebase/firestore-rest.ts
@@ -115,31 +115,6 @@ export async function deleteDoc(path: string): Promise<void> {
   if (!res.ok && res.status !== 404) throw new Error(`DELETE ${path}: ${res.status}`);
 }
 
-export async function incrementField(docPath: string, field: string, amount: number): Promise<void> {
-  const headers = await authHeaders();
-  const docName = `projects/${PID}/databases/(default)/documents/${docPath}`;
-  const res = await fetch(
-    `https://firestore.googleapis.com/v1/projects/${PID}/databases/(default)/documents:commit`,
-    {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        writes: [
-          {
-            transform: {
-              document: docName,
-              fieldTransforms: [
-                { fieldPath: field, increment: { integerValue: String(amount) } },
-              ],
-            },
-          },
-        ],
-      }),
-    }
-  );
-  if (!res.ok) throw new Error(`INCREMENT ${docPath}.${field}: ${res.status}`);
-}
-
 export async function addDoc(collectionPath: string, data: Record<string, unknown>): Promise<string> {
   const headers = await authHeaders();
   const res = await fetch(`${BASE}/${collectionPath}`, {


### PR DESCRIPTION
## Summary
- The Firestore commit API `transform` write type was silently failing, causing catch-block reverts (the "snap back")
- Replaced with `mergeDoc` read-then-write, which is safe under `busyRef` serialization
- Removed broken `incrementField` from firestore-rest.ts
- Removed re-throw to prevent unhandled rejections

## Test plan
- [x] 100/100 e2e tests pass
- [ ] Manual: tap like button rapidly, verify count stays stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)